### PR TITLE
Use configured Jenkins URL rather than url from request

### DIFF
--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerFactory.java
@@ -43,7 +43,7 @@ public abstract class ThemeManagerFactory extends AbstractDescribableImpl<ThemeM
    */
   public String toAssetUrl(String asset) {
     ThemeManagerFactoryDescriptor descriptor = getDescriptor();
-    return Jenkins.get().getRootUrlFromRequest() + "theme-" + descriptor.getThemeId() + "/" + asset;
+    return Jenkins.get().getRootUrl() + "theme-" + descriptor.getThemeId() + "/" + asset;
   }
 
   /**


### PR DESCRIPTION
I have a Jenkins installation behind a reverse proxy and I have configured the Jenkins URL, but the CSS is loading with this url:
> http://10.133.45.232:8080/extra-path/jenkins/theme-dark/theme.css

Reading the documentation, I think the method `getRootUrl` should be used: https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getRootUrl--
It will try first to get the configured URL and then fallback to `getRootUrlFromRequest`.