### PR TITLE
Switch properties to a JavaScript API to support system themes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerBluePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerBluePageDecorator.java
@@ -28,4 +28,15 @@ public class ThemeManagerBluePageDecorator extends BluePageDecorator {
         }
         return null;
     }
+
+    @SuppressWarnings("unused") // called by jelly
+    public boolean isRespectSystemAppearance() {
+        ThemeManagerPageDecorator themeManagerPageDecorator = ThemeManagerPageDecorator.get();
+        Theme theme = themeManagerPageDecorator.findTheme();
+
+        if (theme.isBlueOceanCompatible()) {
+            return themeManagerPageDecorator.isRespectSystemAppearance();
+        }
+        return false;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator.java
@@ -102,6 +102,8 @@ public class ThemeManagerPageDecorator extends PageDecorator {
                 .collect(Collectors.toSet());
 
         ThemeManagerFactory themeManagerFactory = findThemeFactory();
+        namespacedThemes.add(themeManagerFactory.getTheme().generateProperties());
+
         if (!themeManagerFactory.getDescriptor().isNamespaced()) {
             Set<String> data =
                     new LinkedHashSet<>(themeManagerFactory.getTheme().generateHeaderElements(injectCss));
@@ -117,6 +119,13 @@ public class ThemeManagerPageDecorator extends PageDecorator {
         ThemeManagerFactory themeFactory = findThemeFactory();
 
         return themeFactory.getDescriptor().getThemeKey();
+    }
+
+    @SuppressWarnings("unused") // called by jelly
+    public boolean isRespectSystemAppearance() {
+        ThemeManagerFactory themeFactory = findThemeFactory();
+
+        return themeFactory.getTheme().isRespectSystemAppearance();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerSimplePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeManagerSimplePageDecorator.java
@@ -20,4 +20,9 @@ public class ThemeManagerSimplePageDecorator extends SimplePageDecorator {
     public String getThemeKey() {
         return ThemeManagerPageDecorator.get().getThemeKey();
     }
+
+    @SuppressWarnings("unused") // called by jelly
+    public boolean isRespectSystemAppearance() {
+        return ThemeManagerPageDecorator.get().isRespectSystemAppearance();
+    }
 }

--- a/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/header.jelly
+++ b/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/header.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <script id="theme-manager-theme" type="application/json">{ "id": "${it.themeKey}" }</script>
-  <st:adjunct includes="io.jenkins.plugins.thememanager.header.main" />
+  <script id="theme-manager-theme" type="application/json">{ "id": "${it.themeKey}", "respect_system_appearance":  ${it.respectSystemAppearance} }</script>
   ${it.getHeaderHtml()}
+  <st:adjunct includes="io.jenkins.plugins.thememanager.header.main" />
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/thememanager/header/main.js
+++ b/src/main/resources/io/jenkins/plugins/thememanager/header/main.js
@@ -1,6 +1,23 @@
-const themeJson = document.getElementById('theme-manager-theme').text
-const theme = JSON.parse(themeJson);
+(function () {
+  const themeJson = document.getElementById('theme-manager-theme').text
+  const theme = JSON.parse(themeJson);
 
-if (theme.id && theme.id !== '') {
+  if (theme.id && theme.id !== '') {
     document.documentElement.dataset.theme = theme.id
-}
+  }
+  window.isSystemRespectingTheme = theme.respect_system_appearance
+
+  const propertiesJson = document.getElementById('theme-manager-properties').text
+  const parsedProperties = JSON.parse(propertiesJson);
+
+
+  window.getThemeManagerProperty = function (plugin, propertyName) {
+    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+
+    let propertyNameNormalised = propertyName
+    if (isSystemRespectingTheme) {
+      propertyNameNormalised = isDark ? `${propertyName}-dark` : `${propertyName}-light`
+    }
+    return parsedProperties[`${plugin}:${propertyNameNormalised}`]
+  }
+})()


### PR DESCRIPTION
New JavaScript API, expected use:

```javascript
if (window.getThemeManagerProperty) {
    setTheme();

    if (window.isSystemRespectingTheme) {
        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
            setTheme()
        });
    }

function setTheme() {
  const theme = window.getThemeManagerProperty('your-plugin-name', 'theme') || 'your-fallback'
}

}
```

For theme adaption see:
https://github.com/jenkinsci/dark-theme-plugin/pull/385

For plugin adaption see:
https://github.com/jenkinsci/workflow-cps-plugin/pull/769