### PR TITLE
Activate Spotless via Maven property rather than file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.59</version>
+    <version>4.61</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -31,6 +31,7 @@
     <revision>1.7</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Many thanks for adopting the standard Spotless configuration, which has enabled me to streamline its activation in plugin parent POM 4.61. It is now possible to delete `.mvn_exec_spotless` and add `<spotless.check.skip>false</spotless.check.skip>` instead, which I think makes for a more readable configuration.