### PR TITLE
Use gitHubRepo property in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <version>${changelist}</version>
   <packaging>hpi</packaging>
   <name>Theme Manager</name>
-  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <url>https://github.com/${gitHubRepo}</url>
 
   <licenses>
     <license>
@@ -25,10 +25,11 @@
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.361.4</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>


### PR DESCRIPTION
## Use gitHubRepo property in pom file
    
Missed from 192.v43b_71661283b_ release.  Plugin BOM builds fail.

https://github.com/jenkinsci/bom/pull/2015

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
