### PR TITLE
Require Jenkins 2.426.1 LTS or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.421</jenkins.version>
+    <jenkins.version>2.426.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.426.x</artifactId>
         <version>2675.v1515e14da_7a_6</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
Now that the baseline is available in LTS form, prefer it for the reasons given in [the documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).