### PR TITLE
Refine theme manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.5</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -31,7 +31,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.426</jenkins.baseline>
+    <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
+        <version>3893.v213a_42768d35</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
@@ -64,6 +64,7 @@ public class ThemeUserProperty extends UserProperty {
         @NonNull
         @Override
         public String getDisplayName() {
+            return "Theme";
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import hudson.model.userproperty.UserPropertyCategory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -63,7 +64,6 @@ public class ThemeUserProperty extends UserProperty {
         @NonNull
         @Override
         public String getDisplayName() {
-            return "Themes";
         }
 
         @Override
@@ -71,15 +71,9 @@ public class ThemeUserProperty extends UserProperty {
             return new ThemeUserProperty();
         }
 
-        //        @Override
-        //        public @NonNull UserPropertyCategory getUserPropertyCategory() {
-        //            return UserPropertyCategory.get(UserPropertyCategory.Appearance.class);
-        //        }
-
-        // replace with above method when bumping core to version including:
-        // https://github.com/jenkinsci/jenkins/pull/7268
-        public @CheckForNull String getUserPropertyCategoryAsString() {
-            return "appearance";
+        @Override
+        public @NonNull UserPropertyCategory getUserPropertyCategory() {
+            return UserPropertyCategory.get(UserPropertyCategory.Appearance.class);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/ThemeUserProperty.java
@@ -7,6 +7,7 @@ import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import hudson.model.userproperty.UserPropertyCategory;
+import io.jenkins.plugins.thememanager.none.NoOpThemeManagerFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -21,6 +22,10 @@ public class ThemeUserProperty extends UserProperty {
     public ThemeUserProperty() {}
 
     public ThemeManagerFactory getTheme() {
+        if (theme == null) {
+            return new NoOpThemeManagerFactory();
+        }
+
         return theme;
     }
 

--- a/src/main/java/io/jenkins/plugins/thememanager/none/NoOpThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/thememanager/none/NoOpThemeManagerFactory.java
@@ -21,7 +21,7 @@ public class NoOpThemeManagerFactory extends ThemeManagerFactory {
         return Theme.builder().build();
     }
 
-    @Extension
+    @Extension(ordinal = 999)
     public static class NoOpThemeManagerFactoryDescriptor extends ThemeManagerFactoryDescriptor {
 
         @NonNull

--- a/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/global.jelly
+++ b/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/global.jelly
@@ -1,13 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:th="/lib/theme-manager">
-  <f:section title="${%Themes}">
-    <a class="tm-link" href="${rootURL}/manage/pluginManager/available?filter=UI Themes">
-      <j:set var="icon">
-        <l:icon src="symbol-plugins" />
-      </j:set>
-      <j:out value="${%plugin-link(icon)}" />
-    </a>
-
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:th="/lib/theme-manager">
+  <f:section title="${%Theme}">
     <th:selector />
 
     <f:entry field="disableUserThemes">

--- a/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/global.properties
+++ b/src/main/resources/io/jenkins/plugins/thememanager/ThemeManagerPageDecorator/global.properties
@@ -1,1 +1,0 @@
-plugin-link=You can get more themes at {0} Plugins

--- a/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
+++ b/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
@@ -53,14 +53,14 @@
     flex-direction: column;
     text-align: center;
     cursor: pointer;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight, 450);
 }
 
 .app-theme-picker__item label div {
     display: flex;
     flex-direction: column;
     width: 100%;
-    border-radius: 10px;
+    border-radius: var(--form-input-border-radius);
     margin-bottom: 0.75rem;
     overflow: hidden;
 }
@@ -131,19 +131,24 @@
     border-color: var(--input-border-hover);
 }
 
+.tm-link2 {
+    display: flex;
+    align-items: center;
+}
+
 .tm-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.4ch;
-    float: right;
-}
+    margin-left: 0.4ch;
 
-.tm-link svg {
-    width: 1rem;
-    height: 1rem;
-}
+    svg {
+        width: 1rem;
+        height: 1rem;
 
-.tm-link svg * {
-    stroke-width: 45px;
+        * {
+            stroke-width: 45px;
+        }
+    }
 }

--- a/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
+++ b/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
@@ -131,7 +131,7 @@
     border-color: var(--input-border-hover);
 }
 
-.tm-link2 {
+.tm-description {
     display: flex;
     align-items: center;
 }

--- a/src/main/resources/lib/theme-manager/selector.jelly
+++ b/src/main/resources/lib/theme-manager/selector.jelly
@@ -1,12 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <j:invokeStatic var="descriptors" className="io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor" method="all"/>
-
-  <st:adjunct includes="io.jenkins.plugins.thememanager.style.main" />
-
-  <st:adjunct includes="lib.form.radioBlock.radioBlock"/>
-
-  <div class="jenkins-section__description tm-link2">
+  <div class="jenkins-section__description tm-description">
     ${%description}
     <j:if test="${app.hasPermission(app.ADMINISTER)}">
       ${%get-themes}
@@ -18,6 +12,12 @@
       </a>.
     </j:if>
   </div>
+
+  <j:invokeStatic var="descriptors" className="io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor" method="all"/>
+
+  <st:adjunct includes="io.jenkins.plugins.thememanager.style.main" />
+
+  <st:adjunct includes="lib.form.radioBlock.radioBlock"/>
 
   <f:entry field="theme">
     <div class="app-theme-picker">

--- a/src/main/resources/lib/theme-manager/selector.jelly
+++ b/src/main/resources/lib/theme-manager/selector.jelly
@@ -1,12 +1,25 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <j:invokeStatic var="descriptors" className="io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor" method="all"/>
 
   <st:adjunct includes="io.jenkins.plugins.thememanager.style.main" />
 
   <st:adjunct includes="lib.form.radioBlock.radioBlock"/>
 
-  <f:entry title="${%Select theme}" field="theme">
+  <div class="jenkins-section__description tm-link2">
+    ${%description}
+    <j:if test="${app.hasPermission(app.ADMINISTER)}">
+      ${%get-themes}
+      <a class="tm-link" href="${rootURL}/manage/pluginManager/available?filter=UI Themes">
+        <j:set var="icon">
+          <l:icon src="symbol-plugins" />
+        </j:set>
+        <j:out value="${%plugin-link(icon)}" />
+      </a>.
+    </j:if>
+  </div>
+
+  <f:entry field="theme">
     <div class="app-theme-picker">
       <j:set var="currentInstance" value="${instance['theme']}" />
       <j:set var="currentDescriptor" value="${currentInstance.descriptor}" />

--- a/src/main/resources/lib/theme-manager/selector.properties
+++ b/src/main/resources/lib/theme-manager/selector.properties
@@ -1,0 +1,3 @@
+description=Select a theme to change how Jenkins appears.
+get-themes=You can get more themes at
+plugin-link={0} Plugins


### PR DESCRIPTION
**Before**
<img width="863" alt="image" src="https://github.com/user-attachments/assets/49461d08-2a7f-4cd4-8357-63f31bce7ea0" />

**After**
<img width="856" alt="image" src="https://github.com/user-attachments/assets/dd409f17-fc7f-4ac7-8568-d5c91c847383" />

**Changes**
* Change 'Themes' to 'Theme'
  * Using “Theme” (singular) better reflects its purpose: to select one theme, not a collection of themes
* Add a description (consistent with recent core PRs https://github.com/jenkinsci/jenkins/pull/9833) - move 'Get themes' link inside of the description rather than floating to the right
* The default theme has been moved to be first, and is preselected if a theme hasn't been selected
* Mild CSS tweaks
* Update to latest Jenkins version

### Testing done

* Works as before

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
