### PR TITLE
Remove Plugins link

### DIFF
--- a/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
+++ b/src/main/resources/io/jenkins/plugins/thememanager/style/main.css
@@ -131,11 +131,6 @@
     border-color: var(--input-border-hover);
 }
 
-.tm-description {
-    display: flex;
-    align-items: center;
-}
-
 .tm-link {
     display: inline-flex;
     align-items: center;

--- a/src/main/resources/lib/theme-manager/selector.jelly
+++ b/src/main/resources/lib/theme-manager/selector.jelly
@@ -1,16 +1,7 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <div class="jenkins-section__description tm-description">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <div class="jenkins-section__description">
     ${%description}
-    <j:if test="${app.hasPermission(app.ADMINISTER)}">
-      ${%get-themes}
-      <a class="tm-link" href="${rootURL}/manage/pluginManager/available?filter=UI Themes">
-        <j:set var="icon">
-          <l:icon src="symbol-plugins" />
-        </j:set>
-        <j:out value="${%plugin-link(icon)}" />
-      </a>.
-    </j:if>
   </div>
 
   <j:invokeStatic var="descriptors" className="io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor" method="all"/>

--- a/src/main/resources/lib/theme-manager/selector.properties
+++ b/src/main/resources/lib/theme-manager/selector.properties
@@ -1,3 +1,1 @@
 description=Select a theme to change how Jenkins appears.
-get-themes=You can get more themes at
-plugin-link={0} Plugins


### PR DESCRIPTION
Relates to https://github.com/jenkinsci/jenkins/pull/10478. That PR now includes a Plugins link at the top of the Appearance page, so this is no longer needed.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/f41bc929-4932-468a-87d2-aba35c92d971" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
